### PR TITLE
CyberConnect Indexer Challenge 3 - Expanding API Data Gathering

### DIFF
--- a/fetcher/general.go
+++ b/fetcher/general.go
@@ -26,6 +26,7 @@ const (
 const (
 	ContextUrl          = "https://context.app/api/profile/%s"
 	SuperrareUrl        = "https://superrare.com/api/v2/user?address=%s"
+	FoundationUrl       = "https://api.thegraph.com/subgraphs/name/f8n/fnd"
 	RaribleFollowingUrl = "https://api-mainnet.rarible.com/marketplace/api/v4/followings?owner=%s"
 	RaribleFollowerUrl  = "https://api-mainnet.rarible.com/marketplace/api/v4/followers?user=%s"
 )
@@ -42,29 +43,31 @@ type ConnectionEntry struct {
 }
 
 type IdentityEntryList struct {
-	OpenSea    []UserOpenSeaIdentity
-	Twitter    []UserTwitterIdentity
-	Superrare  []UserSuperrareIdentity
-	Rarible    []UserRaribleIdentity
-	Context    []UserContextIdentity
-	Zora       []UserZoraIdentity
-	Foundation []UserFoundationIdentity
-	Showtime   []UserShowtimeIdentity
-	Ens        string
+	OpenSea             []UserOpenSeaIdentity
+	Twitter             []UserTwitterIdentity
+	Superrare           []UserSuperrareIdentity
+	Rarible             []UserRaribleIdentity
+	Context             []UserContextIdentity
+	Zora                []UserZoraIdentity
+	Foundation          []UserFoundationIdentity
+	FoundationNonSocial []UserFoundationIdentityNonSocial
+	Showtime            []UserShowtimeIdentity
+	Ens                 string
 }
 
 type IdentityEntry struct {
-	OpenSea    *UserOpenSeaIdentity
-	Twitter    *UserTwitterIdentity
-	Superrare  *UserSuperrareIdentity
-	Rarible    *UserRaribleIdentity
-	Context    *UserContextIdentity
-	Zora       *UserZoraIdentity
-	Ens        *UserEnsIdentity
-	Foundation *UserFoundationIdentity
-	Showtime   *UserShowtimeIdentity
-	Err        error
-	Msg        string
+	OpenSea             *UserOpenSeaIdentity
+	Twitter             *UserTwitterIdentity
+	Superrare           *UserSuperrareIdentity
+	Rarible             *UserRaribleIdentity
+	Context             *UserContextIdentity
+	Zora                *UserZoraIdentity
+	Ens                 *UserEnsIdentity
+	Foundation          *UserFoundationIdentity
+	FoundationNonSocial *UserFoundationIdentityNonSocial
+	Showtime            *UserShowtimeIdentity
+	Err                 error
+	Msg                 string
 }
 
 type UserTwitterIdentity struct {
@@ -124,6 +127,31 @@ type UserFoundationIdentity struct {
 	Facebook   string
 	Snapchat   string
 	Instagram  string
+	DataSource string
+}
+
+type UserFoundationIdentityNonSocial struct {
+	IsAdmin         bool
+	NetRevenueInETH string
+	// Deliberately leaving json tags on below structs to allow assignment in processFoundationNonSocial
+	Nfts []struct {
+		TokenIPFSPath      string `json:"tokenIPFSPath"`
+		Name               string `json:"name"`
+		Description        string `json:"description"`
+		Image              string `json:"image"`
+		LastSalePriceInETH string `json:"lastSalePriceInETH"`
+		DateMinted         string `json:"dateMinted"`
+	} `json:"nfts"`
+	Creator struct {
+		NetSalesInETH          string `json:"netSalesInETH"`
+		NetSalesPendingInETH   string `json:"netSalesPendingInETH"`
+		NetRevenueInETH        string `json:"netRevenueInETH"`
+		NetRevenueInPendingETH string `json:"netRevenueInPendingETH"`
+	} `json:"creator"`
+	Withdrawals []struct {
+		AmountInETH string `json:"amountInETH"`
+		Date        string `json:"date"`
+	}
 	DataSource string
 }
 
@@ -187,6 +215,34 @@ type SuperrareProfile struct {
 		SpotifyLink    string `json:"spotifyLink"`
 		SoundCloudLink string `json:"soundcloudLink"`
 	} `json:"result"`
+}
+
+type FoundationProfileNonSocial struct {
+	Data struct {
+		Accounts []struct {
+			IsAdmin         bool   `json:"isAdmin"`
+			NetRevenueInETH string `json:"netRevenueInETH"`
+
+			Nfts []struct {
+				TokenIPFSPath      string `json:"tokenIPFSPath"`
+				Name               string `json:"name"`
+				Description        string `json:"description"`
+				Image              string `json:"image"`
+				LastSalePriceInETH string `json:"lastSalePriceInETH"`
+				DateMinted         string `json:"dateMinted"`
+			} `json:"nfts"`
+			Creator struct {
+				NetSalesInETH          string `json:"netSalesInETH"`
+				NetSalesPendingInETH   string `json:"netSalesPendingInETH"`
+				NetRevenueInETH        string `json:"netRevenueInETH"`
+				NetRevenueInPendingETH string `json:"netRevenueInPendingETH"`
+			} `json:"creator"`
+			Withdrawals []struct {
+				AmountInETH string `json:"amountInETH"`
+				Date        string `json:"date"`
+			} `json:"withdrawals"`
+		} `json:"accounts"`
+	} `json:"data"`
 }
 
 type FoundationIdentity struct {

--- a/fetcher/identity.go
+++ b/fetcher/identity.go
@@ -20,6 +20,7 @@ func (f *fetcher) FetchIdentity(address string) (IdentityEntryList, error) {
 	// Superrare API
 	go f.processSuperrare(address, ch)
 	// Part 2 - Add other data source here
+	go f.processFoundationNonSocial(address, ch)
 	// TODO
 
 	// Final Part - Merge entry
@@ -50,6 +51,9 @@ func (f *fetcher) FetchIdentity(address string) (IdentityEntryList, error) {
 		}
 		if entry.Foundation != nil {
 			identityArr.Foundation = append(identityArr.Foundation, *entry.Foundation)
+		}
+		if entry.FoundationNonSocial != nil {
+			identityArr.FoundationNonSocial = append(identityArr.FoundationNonSocial, *entry.FoundationNonSocial)
 		}
 		if entry.Showtime != nil {
 			identityArr.Showtime = append(identityArr.Showtime, *entry.Showtime)
@@ -182,5 +186,86 @@ func (f *fetcher) processSuperrare(address string, ch chan<- IdentityEntry) {
 		result.Superrare = &newSprRecord
 	}
 
+	ch <- result
+}
+
+// processFoundationNonSocial will query the Foundation GraphQL API
+// The Foundation API does not provide endpoints for social media at this moment
+// processFoundationNonSocial will get NFT, ETH Financial and Creator data for an address instead
+func (f *fetcher) processFoundationNonSocial(address string, ch chan<- IdentityEntry) {
+	var result IdentityEntry
+
+	// GraphQL query that gets data from an account that matches the address
+	gqlQuery := map[string]string{
+		"query": fmt.Sprintf(`{
+			accounts(where: {id: "%s"}) {
+					isAdmin,
+					netRevenueInETH,
+					nfts {
+						tokenIPFSPath,
+						name,
+						description,
+						image,
+						dateMinted,
+						lastSalePriceInETH
+					}
+					creator {
+						netSalesInETH,
+						netSalesPendingInETH,
+						netRevenueInETH,
+						netRevenuePendingInETH
+					}
+					withdrawals {
+						amountInETH,
+						date
+					}
+				}
+			}
+		`, address),
+	}
+
+	jsonQuery, err := json.Marshal(gqlQuery)
+	if err != nil {
+		result.Err = err
+		result.Msg = "[processFoundationNonSocial] Marshalling GraphQL query to JSON failed"
+		ch <- result
+		return
+	}
+
+	// sending a POST request which contains the GraphQL query in the body
+	body, err := sendRequest(f.httpClient, RequestArgs{
+		url:    FoundationUrl,
+		method: "POST",
+		body:   jsonQuery,
+	})
+	if err != nil {
+		result.Err = err
+		result.Msg = "[processFoundationNonSocial] fetch identity failed"
+		ch <- result
+		return
+	}
+	fndProfile := FoundationProfileNonSocial{}
+	err = json.Unmarshal(body, &fndProfile)
+	if err != nil {
+		result.Err = err
+		result.Msg = "[processFoundationNonSocial] identity response json unmarshal failed"
+		ch <- result
+		return
+	}
+	// using Accounts[0] here since the JSON response is an array of accounts but we are only using one address currently
+	var newFndRecord UserFoundationIdentityNonSocial
+	if len(fndProfile.Data.Accounts) > 0 {
+		newFndRecord = UserFoundationIdentityNonSocial{
+			IsAdmin:         fndProfile.Data.Accounts[0].IsAdmin,
+			NetRevenueInETH: fndProfile.Data.Accounts[0].NetRevenueInETH,
+			Nfts:            fndProfile.Data.Accounts[0].Nfts,
+			Creator:         fndProfile.Data.Accounts[0].Creator,
+			Withdrawals:     fndProfile.Data.Accounts[0].Withdrawals,
+			DataSource:      FOUNDATION,
+		}
+	}
+	if len(newFndRecord.Nfts) != 0 || len(newFndRecord.Withdrawals) != 0 || newFndRecord.NetRevenueInETH != "0" || newFndRecord.IsAdmin != false {
+		result.FoundationNonSocial = &newFndRecord
+	}
 	ch <- result
 }

--- a/main.go
+++ b/main.go
@@ -8,7 +8,10 @@ import (
 
 const (
 	// address = "0xd8da6bf26964af9d7eed9e03e53415d37aa96045" // vitalik.eth
-	address = "0x983110309620d911731ac0932219af06091b6744" // brantly.eth
+	// address = "0x983110309620d911731ac0932219af06091b6744" // brantly.eth
+
+	// Example address below which has a few NFTs tied to it on Foundation
+	address = "0x000000064730640b7d670408d74280924883064f"
 )
 
 func main() {


### PR DESCRIPTION
Hi,

For this challenge I'm focusing on expanding the amount of data the indexer is getting from APIs. I plan to add a few more commits over the next few days to this PR which pulls data from services other than Foundation.

The first commit in this PR adds support for pulling NFT, ETH Financial and Creator data from the [GraphQL Foundation API](https://thegraph.com/hosted-service/subgraph/f8n/fnd). This Foundation API is very extensive and I've only covered a small part of it, but it does not include much social/user data so I made a point of marking my new structs/funcs as "NonSocial".

Please let me know of any feedback or suggestions!