### PR TITLE
Gitcoin Challenge 3 - Advanced Fetcher （DavidCai）

### DIFF
--- a/fetcher/general.go
+++ b/fetcher/general.go
@@ -12,6 +12,7 @@ const (
 	SYBIL      = "Sybil"
 	SUPERRARE  = "Superrare"
 	INFURA     = "Infura"
+	ENS        = "ENS"
 )
 
 const (
@@ -26,8 +27,20 @@ const (
 const (
 	ContextUrl          = "https://context.app/api/profile/%s"
 	SuperrareUrl        = "https://superrare.com/api/v2/user?address=%s"
+	RaribleUrl          = "https://api-mainnet.rarible.com/marketplace/api/v4/users/%s"
 	RaribleFollowingUrl = "https://api-mainnet.rarible.com/marketplace/api/v4/followings?owner=%s"
 	RaribleFollowerUrl  = "https://api-mainnet.rarible.com/marketplace/api/v4/followers?user=%s"
+	EnsUrl              = "https://api.thegraph.com/subgraphs/name/ensdomains/ens"
+	FoundationUrl       = "https://hasura2.foundation.app/v1/graphql"
+	OpenSeaUrl          = "https://api.opensea.io/api/v1/account/%s"
+
+	// NOTE: To get more social media info, we fetch from the Showtime and Zora
+	// URLs that containing some hash value (they are the actual URLs the profile
+	// pages are using) instead of their open APIs and subgraphs,
+	// which means some manual hash updating is needed after regular CI
+	// tests failure.
+	ShowtimeUrl = "https://showtime.io/_next/data/Sm5FJTco3-PFeQEyPnwyB/%s.json"
+	ZoraUrl     = "https://d2ydi2tmw4j98m.cloudfront.net/user/batch?addresses=%s"
 )
 
 type ConnectionEntryList struct {
@@ -75,6 +88,7 @@ type UserTwitterIdentity struct {
 type UserRaribleIdentity struct {
 	Username        string
 	Homepage        string
+	Twitter         string
 	ItemSold        int
 	AmountSoldInEth float64
 	DataSource      string
@@ -130,6 +144,7 @@ type UserFoundationIdentity struct {
 type UserZoraIdentity struct {
 	Username   string
 	Website    string
+	Bio        string
 	DataSource string
 }
 

--- a/fetcher/identity.go
+++ b/fetcher/identity.go
@@ -1,13 +1,16 @@
 package fetcher
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
+	"strings"
 
+	"github.com/valyala/fastjson"
 	"go.uber.org/zap"
 )
 
-const IdentityApiCount = 2
+const IdentityApiCount = 8
 
 func (f *fetcher) FetchIdentity(address string) (IdentityEntryList, error) {
 
@@ -20,7 +23,18 @@ func (f *fetcher) FetchIdentity(address string) (IdentityEntryList, error) {
 	// Superrare API
 	go f.processSuperrare(address, ch)
 	// Part 2 - Add other data source here
-	// TODO
+	// ENS reverse resolution
+	go f.processENS(address, ch)
+	// OpenSeaAPI
+	go f.processOpenSea(address, ch)
+	// Foundation Subgraph
+	go f.processFoundation(address, ch)
+	// Rarible API
+	go f.processRarible(address, ch)
+	// Zora API
+	go f.processZora(address, ch)
+	// Showtime API
+	go f.processShowtime(address, ch)
 
 	// Final Part - Merge entry
 	for i := 0; i < IdentityApiCount; i++ {
@@ -183,4 +197,261 @@ func (f *fetcher) processSuperrare(address string, ch chan<- IdentityEntry) {
 	}
 
 	ch <- result
+}
+
+func (f *fetcher) processFoundation(address string, ch chan<- IdentityEntry) {
+	var result IdentityEntry
+
+	defer func() { ch <- result }()
+
+	query := map[string]interface{}{
+		"query": `
+				query UserProfileByPublicKey($publicKey: String!) {
+					user: user_by_pk(publicKey: $publicKey) {
+						publicKey
+						username
+						bio
+						links
+						twitSocialVerifs: socialVerifications(
+							where: { isValid: { _eq: true }, service: { _eq: "TWITTER" } }
+							limit: 1
+						) {
+							userId
+							username
+						}
+						instaSocialVerifs: socialVerifications(
+							where: { isValid: { _eq: true }, service: { _eq: "INSTAGRAM" } }
+							limit: 1
+						) {
+							userId
+							username
+						}
+					}
+				}
+		`,
+		"variables": map[string]string{"publicKey": address},
+	}
+
+	queryBytes, _ := json.Marshal(query)
+
+	body, err := sendRequest(f.httpClient, RequestArgs{
+		url:    FoundationUrl,
+		method: "POST",
+		body:   bytes.NewBuffer(queryBytes).Bytes(),
+	})
+
+	if err != nil {
+		result.Err = err
+		result.Msg = "[processFoundation] fetch identity failed"
+		return
+	}
+
+	username := fastjson.GetString(body, "data", "user", "username")
+
+	if len(username) != 0 {
+		result.Foundation = &UserFoundationIdentity{
+			Username:   username,
+			Bio:        fastjson.GetString(body, "data", "user", "bio"),
+			Tiktok:     fastjson.GetString(body, "data", "user", "links", "tiktok", "handle"),
+			Twitch:     fastjson.GetString(body, "data", "user", "links", "twitch", "handle"),
+			Discord:    fastjson.GetString(body, "data", "user", "links", "discord", "handle"),
+			Twitter:    fastjson.GetString(body, "data", "user", "twitSocialVerifs", "0", "username"),
+			Website:    fastjson.GetString(body, "data", "user", "links", "website", "handle"),
+			Youtube:    fastjson.GetString(body, "data", "user", "links", "youtube", "handle"),
+			Facebook:   fastjson.GetString(body, "data", "user", "links", "facebook", "handle"),
+			Snapchat:   fastjson.GetString(body, "data", "user", "links", "snapchat", "handle"),
+			Instagram:  fastjson.GetString(body, "data", "user", "instaSocialVerifs", "0", "username"),
+			DataSource: FOUNDATION,
+		}
+	}
+}
+
+func (f *fetcher) processRarible(address string, ch chan<- IdentityEntry) {
+	var result IdentityEntry
+
+	defer func() { ch <- result }()
+
+	body, err := sendRequest(f.httpClient, RequestArgs{
+		url:    fmt.Sprintf(RaribleUrl, address),
+		method: "GET",
+	})
+
+	if err != nil {
+		result.Err = err
+		result.Msg = "[processRarible] fetch identity failed"
+		return
+	}
+
+	username := fastjson.GetString(body, "username")
+
+	if len(username) != 0 {
+		result.Rarible = &UserRaribleIdentity{
+			Username:   username,
+			Homepage:   fastjson.GetString(body, "website"),
+			Twitter:    fastjson.GetString(body, "twitterUsername"),
+			DataSource: RARIBLE,
+		}
+	}
+}
+
+func (f *fetcher) processZora(address string, ch chan<- IdentityEntry) {
+	var result IdentityEntry
+
+	defer func() { ch <- result }()
+
+	body, err := sendRequest(f.httpClient, RequestArgs{
+		url:    fmt.Sprintf(ZoraUrl, address),
+		method: "GET",
+	})
+
+	if err != nil {
+		result.Err = err
+		result.Msg = "[processZora] fetch identity failed"
+		return
+	}
+
+	username := fastjson.GetString(body, "0", "username")
+
+	if len(username) != 0 {
+		result.Zora = &UserZoraIdentity{
+			Username:   username,
+			Website:    fastjson.GetString(body, "0", "website"),
+			Bio:        fastjson.GetString(body, "0", "bio"),
+			DataSource: ZORA,
+		}
+	}
+}
+
+func (f *fetcher) processShowtime(address string, ch chan<- IdentityEntry) {
+	var result IdentityEntry
+
+	defer func() { ch <- result }()
+
+	body, err := sendRequest(f.httpClient, RequestArgs{
+		url:    fmt.Sprintf(ShowtimeUrl, address),
+		method: "GET",
+	})
+
+	if err != nil {
+		result.Err = err
+		result.Msg = "[processShowtime] fetch identity failed"
+		return
+	}
+
+	rawValue, err := fastjson.ParseBytes(body)
+
+	if err != nil {
+		result.Err = err
+		result.Msg = "[processShowtime] parse response json failed"
+		return
+	}
+
+	name := fastjson.GetString(body, "pageProps", "profile", "name")
+
+	if len(name) != 0 {
+		result.Showtime = &UserShowtimeIdentity{
+			Name:       name,
+			Username:   fastjson.GetString(body, "pageProps", "profile", "username"),
+			Bio:        fastjson.GetString(body, "pageProps", "profile", "bio"),
+			DataSource: SHOWTIME,
+		}
+
+		links := rawValue.GetArray("pageProps", "profile", "links")
+
+		if len(links) == 0 {
+			return
+		}
+
+		for _, link := range links {
+			handle := string(link.GetStringBytes("user_input"))
+
+			switch string(link.GetStringBytes("type__name")) {
+			case "Twitter":
+				result.Showtime.TwitterHandle = handle
+			case "Linktree":
+				result.Showtime.LinkTreeHandle = handle
+			case "CryptoArt.ai":
+				result.Showtime.CryptoArtHandle = handle
+			case "Foundation":
+				result.Showtime.FoundationHandle = handle
+			case "hicetnunc.art":
+				result.Showtime.HicetnuncHandle = handle
+			case "OpenSea":
+				result.Showtime.OpenseaHandle = handle
+			case "Rarible":
+				result.Showtime.RaribleHandle = handle
+			}
+		}
+	}
+}
+
+func (f *fetcher) processOpenSea(address string, ch chan<- IdentityEntry) {
+	var result IdentityEntry
+
+	defer func() { ch <- result }()
+
+	body, err := sendRequest(f.httpClient, RequestArgs{
+		url:    fmt.Sprintf(OpenSeaUrl, address),
+		method: "GET",
+	})
+
+	if err != nil {
+		result.Err = err
+		result.Msg = "[processOpenSea] fetch identity failed"
+		return
+	}
+
+	username := fastjson.GetString(body, "data", "user", "username")
+
+	if len(username) != 0 {
+		result.OpenSea = &UserOpenSeaIdentity{
+			Username:   username,
+			DataSource: OPENSEA,
+		}
+	}
+}
+
+func (f *fetcher) processENS(address string, ch chan<- IdentityEntry) {
+	var result IdentityEntry
+
+	defer func() { ch <- result }()
+
+	query := map[string]string{
+		"query": fmt.Sprintf(`
+			{
+				registrations(where: { registrant: "%s" }) {
+					id
+					domain {
+						name
+					}
+					registrant {
+						id
+					}
+				}
+			}
+		 `, strings.ToLower(address)),
+	}
+
+	queryBytes, _ := json.Marshal(query)
+
+	body, err := sendRequest(f.httpClient, RequestArgs{
+		url:    EnsUrl,
+		method: "POST",
+		body:   bytes.NewBuffer(queryBytes).Bytes(),
+	})
+
+	if err != nil {
+		result.Err = err
+		result.Msg = "[processENS] fetch identity failed"
+		return
+	}
+
+	domain := fastjson.GetString(body, "data", "registrations", "0", "domain", "name")
+
+	if len(domain) != 0 {
+		result.Ens = &UserEnsIdentity{
+			Ens:        domain,
+			DataSource: ENS,
+		}
+	}
 }

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,8 @@ require (
 	github.com/ethereum/go-ethereum v1.10.12
 	github.com/imdario/mergo v0.3.12
 	github.com/ryboe/q v1.0.15 // indirect
+	github.com/stretchr/testify v1.7.0
+	github.com/valyala/fastjson v1.6.3
 	github.com/wealdtech/go-ens/v3 v3.5.1
 	go.uber.org/zap v1.19.1
 )

--- a/go.sum
+++ b/go.sum
@@ -427,6 +427,7 @@ github.com/status-im/keycard-go v0.0.0-20190316090335-8537d3370df4/go.mod h1:RZL
 github.com/status-im/keycard-go v0.0.0-20200402102358-957c09536969 h1:Oo2KZNP70KE0+IUJSidPj/BFS/RXNHmKIJOdckzml2E=
 github.com/status-im/keycard-go v0.0.0-20200402102358-957c09536969/go.mod h1:RZLeN1LMWmRsyYjvAu+I6Dm9QmlDaIIt+Y+4Kd7Tp+Q=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/objx v0.1.1 h1:2vfRuCMp5sSVIDSqO8oNnWJq7mPa6KVP3iPIwFBuy8A=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.0/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
@@ -449,6 +450,8 @@ github.com/tyler-smith/go-bip39 v1.1.0 h1:5eUemwrMargf3BSLRRCalXT93Ns6pQJIjYQN2n
 github.com/tyler-smith/go-bip39 v1.1.0/go.mod h1:gUYDtqQw1JS3ZJ8UWVcGTGqqr6YIN3CWg+kkNaLt55U=
 github.com/urfave/cli/v2 v2.3.0/go.mod h1:LJmUH05zAU44vOAcrfzZQKsZbVcdbOG8rtL3/XcUArI=
 github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=
+github.com/valyala/fastjson v1.6.3 h1:tAKFnnwmeMGPbwJ7IwxcTPCNr3uIzoIj3/Fh90ra4xc=
+github.com/valyala/fastjson v1.6.3/go.mod h1:CLCAqky6SMuOcxStkYQvblddUtoRxhYMGLrsQns1aXY=
 github.com/valyala/fasttemplate v1.0.1/go.mod h1:UQGH1tvbgY+Nz5t2n7tXsz52dQxojPUpymEIMZ47gx8=
 github.com/valyala/fasttemplate v1.2.1/go.mod h1:KHLXt3tVN2HBp8eijSv/kGJopbvo7S+qRAEEKiv+SiQ=
 github.com/wealdtech/go-ens/v3 v3.5.1 h1:0VqkCjIGfIVdwHIf2QqYWWt3bbR1UE7RwBGx7YPpufQ=

--- a/test/identity_test.go
+++ b/test/identity_test.go
@@ -1,0 +1,90 @@
+package test
+
+import (
+	"testing"
+
+	"github.com/cyberconnecthq/indexer/fetcher"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestProcessOpenSea(t *testing.T) {
+	identity, err := fetcher.NewFetcher().FetchIdentity("0x8AcC5677F98b86c407BFA7861f53857430Ba3904")
+
+	assert.Nil(t, err)
+	assert.Len(t, identity.OpenSea, 1)
+	assert.Equal(t, identity.OpenSea[0].Username, "Vintash")
+	assert.Equal(t, identity.OpenSea[0].DataSource, fetcher.OPENSEA)
+}
+
+func TestProcessENS(t *testing.T) {
+	identity, err := fetcher.NewFetcher().FetchIdentity("0x56706F118e42AE069F20c5636141B844D1324AE1")
+
+	assert.Nil(t, err)
+	assert.Equal(t, identity.Ens, "davidcai.eth")
+}
+
+func TestProcessFoundation(t *testing.T) {
+	identity, err := fetcher.NewFetcher().FetchIdentity("0x56706F118e42AE069F20c5636141B844D1324AE1")
+
+	assert.Nil(t, err)
+	assert.Len(t, identity.Foundation, 1)
+
+	foundationIdentity := identity.Foundation[0]
+	assert.Equal(t, foundationIdentity.Username, "davidcai")
+	assert.Equal(t, foundationIdentity.Bio, "Learning&& coding")
+	assert.Equal(t, foundationIdentity.Tiktok, "DavidCai1111")
+	assert.Equal(t, foundationIdentity.Twitch, "DavidCai1111")
+	assert.Equal(t, foundationIdentity.Discord, "DavidCai#2943")
+	assert.Equal(t, foundationIdentity.Twitter, "DavidCai_1993")
+	assert.Equal(t, foundationIdentity.Website, "davidc.ai")
+	assert.Equal(t, foundationIdentity.Youtube, "https://www.youtube.com/channel/UCDMwJM0qyiWxeqlDYAPXQ3Q")
+	assert.Equal(t, foundationIdentity.Facebook, "DavidCai1111")
+	assert.Equal(t, foundationIdentity.Snapchat, "DavidCai1111")
+	assert.Equal(t, foundationIdentity.Instagram, "davidcai1111")
+	assert.Equal(t, foundationIdentity.DataSource, fetcher.FOUNDATION)
+}
+
+func TestProcessRarible(t *testing.T) {
+	identity, err := fetcher.NewFetcher().FetchIdentity("0xbc67052a5c7dfa09e9fb9ff00b95d8a722d252c5")
+
+	assert.Nil(t, err)
+	assert.NotEmpty(t, identity.Rarible)
+
+	for _, raribleIdentity := range identity.Rarible {
+		if raribleIdentity.DataSource != fetcher.RARIBLE {
+			continue
+		}
+
+		assert.Equal(t, raribleIdentity.Username, "Philipp Kapustin")
+		assert.Equal(t, raribleIdentity.Homepage, "https://linktr.ee/Philipp_Kapustin")
+		assert.Equal(t, raribleIdentity.Twitter, "Phill_Kapustin")
+		assert.Equal(t, raribleIdentity.DataSource, fetcher.RARIBLE)
+
+		return
+	}
+
+	assert.Fail(t, "RARIBLE datasource result should be found")
+}
+func TestProcessZora(t *testing.T) {
+	identity, err := fetcher.NewFetcher().FetchIdentity("0x6b8C6E15818C74895c31A1C91390b3d42B336799")
+
+	assert.Nil(t, err)
+	assert.Len(t, identity.Zora, 1)
+	assert.Equal(t, identity.Zora[0].Username, "juliangilliam")
+	assert.Equal(t, identity.Zora[0].Bio, "LOGIK aka Julian Gilliam is a multidisciplinary artist who's creating a world in the physical and digital space.")
+	assert.Equal(t, identity.Zora[0].Website, "http://www.juliangilliam.com")
+	assert.Equal(t, identity.Zora[0].DataSource, fetcher.ZORA)
+}
+
+func TestProcessShowtime(t *testing.T) {
+	identity, err := fetcher.NewFetcher().FetchIdentity("0x8318b9c0e640114f7ed71de8b65142654573a152")
+
+	assert.Nil(t, err)
+	assert.Len(t, identity.Showtime, 1)
+	assert.Equal(t, identity.Showtime[0].Name, "Arman Alipour")
+	assert.Equal(t, identity.Showtime[0].Username, "armanalipour")
+	assert.Equal(t, identity.Showtime[0].Bio, "Independent Artist , 2d Animator")
+	assert.Equal(t, identity.Showtime[0].TwitterHandle, "armanalipour")
+	assert.Equal(t, identity.Showtime[0].HicetnuncHandle, "tz/tz1UX2tdWZRMiXVYgrfCzUj2PoYrPpxjmbVX")
+	assert.Equal(t, identity.Showtime[0].DataSource, fetcher.SHOWTIME)
+}


### PR DESCRIPTION
- fetch ENS, Rarible, Foundation, Showtime, OpenSea, Zora's user identity from their APIs/subgraphs
     - To get more social media info, we fetch from the Showtime and Zora URLs that containing some hash value (they are the actual URLs the profile pages are using) instead of their open APIs and subgraphs, which means some manual hash updating is needed after regular CI tests failure.
- use fastjson to get better unmarshal performance and cleaner code
- add unit test to make sure the fetcher.process* function always gives the expected output via go test ./test
    - if this project activate GitHub Actions later, the unit test can be a part of CI tests.
- video demo: https://share.vidyard.com/watch/bWYKKm4YDGt6gx1PPLP8dr