### PR TITLE
Fetching twitter identity through uniswap sybil list was added.

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,3 +70,7 @@ type Fetcher interface {
 >> go run main.go
 ```
 
+## Testing
+```sh
+>> go test -v test/*/**
+```

--- a/fetcher/general.go
+++ b/fetcher/general.go
@@ -28,6 +28,7 @@ const (
 	SuperrareUrl        = "https://superrare.com/api/v2/user?address=%s"
 	RaribleFollowingUrl = "https://api-mainnet.rarible.com/marketplace/api/v4/followings?owner=%s"
 	RaribleFollowerUrl  = "https://api-mainnet.rarible.com/marketplace/api/v4/followers?user=%s"
+	TwitterSybilListUrl = "https://raw.githubusercontent.com/Uniswap/sybil-list/master/verified.json"
 )
 
 type ConnectionEntryList struct {
@@ -231,4 +232,12 @@ type FoundationIdentity struct {
 			} `json:"instaSocialVerifs"`
 		} `json:"user"`
 	} `json:"data"`
+}
+
+type TwitterSybilList map[string]struct {
+	Twitter struct {
+		Timestamp uint64 `json:"timestamp"`
+		TweetId   string `json:"tweetID"`
+		Handle    string `json:"handle"`
+	} `json:"twitter"`
 }

--- a/fetcher/identity.go
+++ b/fetcher/identity.go
@@ -7,7 +7,7 @@ import (
 	"go.uber.org/zap"
 )
 
-const IdentityApiCount = 2
+const IdentityApiCount = 3
 
 func (f *fetcher) FetchIdentity(address string) (IdentityEntryList, error) {
 
@@ -19,8 +19,8 @@ func (f *fetcher) FetchIdentity(address string) (IdentityEntryList, error) {
 	go f.processContext(address, ch)
 	// Superrare API
 	go f.processSuperrare(address, ch)
-	// Part 2 - Add other data source here
-	// TODO
+	// Twitter identity through uniswap sybil list
+	go f.processTwitterSybilList(address, ch)
 
 	// Final Part - Merge entry
 	for i := 0; i < IdentityApiCount; i++ {
@@ -180,6 +180,45 @@ func (f *fetcher) processSuperrare(address string, ch chan<- IdentityEntry) {
 		newSprRecord.TwitterLink != "" || newSprRecord.SteemitLink != "" || newSprRecord.Website != "" ||
 		newSprRecord.SpotifyLink != "" || newSprRecord.SoundCloudLink != "" {
 		result.Superrare = &newSprRecord
+	}
+
+	ch <- result
+}
+
+func (f *fetcher) processTwitterSybilList(address string, ch chan<- IdentityEntry) {
+	var result IdentityEntry
+
+	body, err := sendRequest(f.httpClient, RequestArgs{
+		url:    TwitterSybilListUrl,
+		method: "GET",
+	})
+
+	if err != nil {
+		result.Err = err
+		result.Msg = "[processTwitterSybilList] fetch identity failed"
+		ch <- result
+		return
+	}
+
+	tsList := TwitterSybilList{}
+	err = json.Unmarshal(body, &tsList)
+
+	if err != nil {
+		result.Err = err
+		result.Msg = "[processTwitterSybilList] response json unmarshal failed"
+		ch <- result
+		return
+	}
+
+	list_item, found := tsList[address]
+
+	if found {
+		convertedHandle := convertTwitterHandle(list_item.Twitter.Handle)
+		twitterIdentity := UserTwitterIdentity{
+			Handle: convertedHandle,
+			DataSource: SYBIL,
+		}
+		result.Twitter = &twitterIdentity
 	}
 
 	ch <- result

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/ethereum/go-ethereum v1.10.12
 	github.com/imdario/mergo v0.3.12
 	github.com/ryboe/q v1.0.15 // indirect
+	github.com/stretchr/testify v1.7.0 // indirect
 	github.com/wealdtech/go-ens/v3 v3.5.1
 	go.uber.org/zap v1.19.1
 )

--- a/go.sum
+++ b/go.sum
@@ -427,6 +427,7 @@ github.com/status-im/keycard-go v0.0.0-20190316090335-8537d3370df4/go.mod h1:RZL
 github.com/status-im/keycard-go v0.0.0-20200402102358-957c09536969 h1:Oo2KZNP70KE0+IUJSidPj/BFS/RXNHmKIJOdckzml2E=
 github.com/status-im/keycard-go v0.0.0-20200402102358-957c09536969/go.mod h1:RZLeN1LMWmRsyYjvAu+I6Dm9QmlDaIIt+Y+4Kd7Tp+Q=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/objx v0.1.1 h1:2vfRuCMp5sSVIDSqO8oNnWJq7mPa6KVP3iPIwFBuy8A=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.0/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=

--- a/test/identity/process_twitter_sybil_list_test.go
+++ b/test/identity/process_twitter_sybil_list_test.go
@@ -1,0 +1,16 @@
+package test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/cyberconnecthq/indexer/fetcher"
+)
+
+func TestProcessTwitterSybilList(t *testing.T) {
+	identity, err := fetcher.NewFetcher().FetchIdentity("0x90C311e132Db3BBDd2d419062cCcc25A88972ad9")
+
+	assert.Nil(t, err)
+	assert.Equal(t, identity.Twitter[0].Handle, "smamn27")
+	assert.Equal(t, identity.Twitter[0].DataSource, fetcher.SYBIL)
+}


### PR DESCRIPTION
Task was made by doing challenge-1 from gitcoin competition
Description can be found in Issue #1 

Points:
- [Uniswap sybil list (github hosted solution)](https://github.com/Uniswap/sybil-list#use-the-sybil-list)
- `convertTwitterHandle` function usage
- Testing code
- Also #15 with typo fixes was added.

Test result:
```sh
indexer % go test -v test/*/**
=== RUN   TestProcessTwitterSybilList
--- PASS: TestProcessTwitterSybilList (1.27s)
PASS
ok  	command-line-arguments	1.938s
```

